### PR TITLE
Correct last month's cost and kwh

### DIFF
--- a/custom_components/china_southern_power_grid_stat/sensor.py
+++ b/custom_components/china_southern_power_grid_stat/sensor.py
@@ -752,21 +752,21 @@ class CSGCoordinator(DataUpdateCoordinator):
 
         if success_cost:
             (
-                last_month_cost,
-                last_month_kwh_from_cost,
+                _,
+                _,
                 _,  # ladder is discarded
                 last_month_by_day_from_cost,
             ) = result_cost
 
             # for last month, it's safe to calculate total kwh from cost
-            if not last_month_cost:
-                last_month_cost = sum(
-                    d[WF_ATTR_CHARGE] for d in last_month_by_day_from_cost
-                )
-            if not last_month_kwh_from_cost:
-                last_month_kwh_from_cost = sum(
-                    d[WF_ATTR_KWH] for d in last_month_by_day_from_cost
-                )
+            # if not last_month_cost:
+            last_month_cost = sum(
+                d[WF_ATTR_CHARGE] for d in last_month_by_day_from_cost
+            )
+            # if not last_month_kwh_from_cost:
+            last_month_kwh_from_cost = sum(
+                d[WF_ATTR_KWH] for d in last_month_by_day_from_cost
+            )
         else:
             (
                 last_month_cost,


### PR DESCRIPTION
The "charge/queryDayElectricAndTemperature" API always returns the current month's total cost and kWh data, no matter which month is set to the param. We should sum the target month's daily data to get the correct total cost and kWh.